### PR TITLE
removing redundent config directory check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,15 +101,6 @@ impl TryFrom<&HotkeyBinding> for HkmData {
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let mut whkdrc_check = dirs::home_dir().expect("no home directory found");
-    whkdrc_check.push(".config");
-    whkdrc_check.push("whkdrc");
-
-    if !whkdrc_check.exists() {
-        println!("No whkdrc file detected. Please place a configuration file at ~/.config/whkdrc and try again.");
-        return Ok(());
-    }
-
     let shell_binary = WHKDRC.shell.to_string();
 
     match WHKDRC.shell {


### PR DESCRIPTION
Issue I found with #14

This code is only checking the original config directory in the users home.
I don't have this directory at all on my computer so this check  was failing for me even though I did have a valid whkdrc in my custom config home directory.

I think the new coded added in #14 handles all the error cases around loading this file so removing this check entierly seemed more reasonable to me than having it look at the env variable 