### PR TITLE
Set flags to not create new window when spawning shell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::io::Write;
+use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::process::ChildStdin;
 use std::process::Command;
@@ -21,6 +22,8 @@ use win_hotkeys::VKey;
 
 mod parser;
 mod whkdrc;
+
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 lazy_static! {
     static ref WHKDRC: Whkdrc = {
@@ -135,6 +138,7 @@ fn spawn_shell(shell: Shell) -> Result<()> {
             let mut process = Command::new(&shell_binary)
                 .stdin(Stdio::piped())
                 .args(["-Command", "-"])
+                .creation_flags(CREATE_NO_WINDOW)
                 .spawn()?;
 
             let mut stdin = process
@@ -151,6 +155,7 @@ fn spawn_shell(shell: Shell) -> Result<()> {
             let mut process = Command::new(&shell_binary)
                 .stdin(Stdio::piped())
                 .args(["-"])
+                .creation_flags(CREATE_NO_WINDOW)
                 .spawn()?;
 
             let mut stdin = process


### PR DESCRIPTION
Related to https://github.com/LGUG2Z/komorebi/pull/1269

This fixes the issue of `whkd` spawning a console window when launched with winapi through `komorebic`