### PR TITLE
Separate whkd struct data and parser to core and parser crates

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -55,7 +55,7 @@ jobs:
           args: "--locked --release"
       - run: |
           cargo install cargo-wix
-          cargo wix --no-build --nocapture --target ${{ matrix.platform.target }}
+          cargo wix --no-build --nocapture --target ${{ matrix.platform.target }} --package whkd
       - uses: actions/upload-artifact@v4
         with:
           name: whkd-${{ matrix.platform.target }}-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target/
 .idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,8 +953,13 @@ dependencies = [
  "dirs",
  "lazy_static",
  "parking_lot",
+ "whkd_core",
  "win-hotkeys",
 ]
+
+[[package]]
+name = "whkd_core"
+version = "0.2.7"
 
 [[package]]
 name = "win-hotkeys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,12 +954,21 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "whkd_core",
+ "whkd_parser",
  "win-hotkeys",
 ]
 
 [[package]]
 name = "whkd_core"
 version = "0.2.7"
+
+[[package]]
+name = "whkd_parser"
+version = "0.2.7"
+dependencies = [
+ "chumsky",
+ "whkd_core",
+]
 
 [[package]]
 name = "win-hotkeys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = ["core"]
+members = ["core", "parser"]
 
 [workspace.package]
 version = "0.2.7"
 
-[dependencies]
+[workspace.dependencies]
 whkd_core = { version = "0.2.7", path = "core" }
+whkd_parser = { version = "0.2.7", path = "parser" }
 active-win-pos-rs = "0.9"
 chumsky = "0.9"
 clap = { version = "4", features = ["derive"] }
@@ -23,3 +24,15 @@ dirs = "6"
 lazy_static = "1"
 parking_lot = "0.12"
 win-hotkeys = "0.5"
+
+[dependencies]
+whkd_core.workspace = true
+whkd_parser.workspace = true
+active-win-pos-rs.workspace = true
+chumsky.workspace = true
+clap.workspace = true
+color-eyre.workspace = true
+dirs.workspace = true
+lazy_static.workspace = true
+parking_lot.workspace = true
+win-hotkeys.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
 name = "whkd"
-version = "0.2.7"
+version.workspace = true
 description = "A simple hotkey daemon for Windows"
 repository = "https://github.com/LGUG2Z/whkd"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace]
+members = ["core"]
+
+[workspace.package]
+version = "0.2.7"
+
 [dependencies]
+whkd_core = { version = "0.2.7", path = "core" }
 active-win-pos-rs = "0.9"
 chumsky = "0.9"
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "whkd"
-version.workspace = true
 description = "A simple hotkey daemon for Windows"
-repository = "https://github.com/LGUG2Z/whkd"
-edition = "2021"
+version.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,6 +12,8 @@ members = ["core", "parser"]
 
 [workspace.package]
 version = "0.2.7"
+repository = "https://github.com/LGUG2Z/whkd"
+edition = "2021"
 
 [workspace.dependencies]
 whkd_core = { version = "0.2.7", path = "core" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "whkd_core"
+version.workspace = true
+edition = "2021"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,4 +1,6 @@
 [package]
 name = "whkd_core"
+description = "The core data for whkd"
 version.workspace = true
-edition = "2021"
+repository.workspace = true
+edition.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,11 +1,5 @@
-use crate::parser::parser;
-use crate::parser::HotkeyBinding;
-use chumsky::Parser;
-use color_eyre::eyre::eyre;
-use color_eyre::eyre::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Whkdrc {
@@ -45,12 +39,9 @@ impl Display for Shell {
     }
 }
 
-impl Whkdrc {
-    pub fn load(path: &PathBuf) -> Result<Self> {
-        let contents = std::fs::read_to_string(path)?;
-
-        parser()
-            .parse(contents)
-            .map_err(|error| eyre!("could not parse whkdrc: {:?}", error))
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HotkeyBinding {
+    pub keys: Vec<String>,
+    pub command: String,
+    pub process_name: Option<String>,
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "whkd_parser"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+whkd_core.workspace = true
+chumsky.workspace = true

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "whkd_parser"
+description = "A parser for whkd"
 version.workspace = true
-edition = "2021"
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 whkd_core.workspace = true

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,7 @@
+use chumsky::prelude::*;
+use whkd_core::HotkeyBinding;
 use whkd_core::Shell;
 use whkd_core::Whkdrc;
-use whkd_core::HotkeyBinding;
-use chumsky::prelude::*;
 
 #[allow(clippy::too_many_lines)]
 #[must_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
 #![warn(clippy::all)]
 #![allow(clippy::missing_errors_doc, clippy::redundant_pub_crate)]
 
-mod parser;
-
 use clap::Parser;
 use color_eyre::eyre::eyre;
 use color_eyre::eyre::Result;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
-use parser::parser;
 use std::collections::HashMap;
 use std::io::Write;
 use std::os::windows::process::CommandExt;
@@ -19,6 +16,7 @@ use std::process::Stdio;
 use whkd_core::HotkeyBinding;
 use whkd_core::Shell;
 use whkd_core::Whkdrc;
+use whkd_parser::parser;
 use win_hotkeys::error::WHKError;
 use win_hotkeys::HotkeyManager;
 use win_hotkeys::VKey;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,7 @@
-use crate::whkdrc::Shell;
-use crate::whkdrc::Whkdrc;
+use whkd_core::Shell;
+use whkd_core::Whkdrc;
+use whkd_core::HotkeyBinding;
 use chumsky::prelude::*;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HotkeyBinding {
-    pub keys: Vec<String>,
-    pub command: String,
-    pub process_name: Option<String>,
-}
 
 #[allow(clippy::too_many_lines)]
 #[must_use]


### PR DESCRIPTION
This PR separates the WHKD data structs into a `whkd_core` crate and the parser into the `whkd_parser` crate so that 3rd party apps can depend on these crates.